### PR TITLE
Try to improve GPIO speed by calling gpio.setup less

### DIFF
--- a/bin/linux-lock-service
+++ b/bin/linux-lock-service
@@ -17,8 +17,7 @@ var LinuxLockService = function(config) {
       // Construct service dependencies using instructions from the configuration
       // file.
       //
-      this.gpio = new LinuxLock.GPIO()
-      this.gpio = gpio
+      this.gpio = LinuxLock.GPIO 
       this.client = LinuxLock.createClient(this.config.client)
       this.rfidReader = new LinuxLock.RFIDReader(this.config.rfidReader, false)
       var self = this

--- a/lib/gpio.js
+++ b/lib/gpio.js
@@ -100,163 +100,167 @@ module.exports.loadConfig = function(path, done) {
 //   Description: Construct a GPIO object, which will issue commands to the
 //   Raspberry Pi GPIO headers, using instructions parsed from JSON files.
 //
-module.exports.GPIO = function() {
-  //
-  // GPIO#execute(config)
-  //
-  // Parameters:
-  //   config: An object containing a single GPIO configuration, made up of one 
-  //           or more sub-configurations, each of which made up of one or more 
-  //           actions (containing one or more verbs).
-  //
-  // Returns: undefined
-  //
-  // Description: Executes a set of GPIO instructions, using the following
-  // algorithm:
-  //
-  // If configuration is an array, execute each element (sub-configuration) of
-  // the array in parallel. Otherwise, treat the object as a single
-  // sub-configuration and execute it.
-  //
-  // For each sub-configuration, there should be an "action" key. The value of
-  // this action key may be an array or object. If it is an array, each element
-  // in the array shall be executed in series.
-  //
-  // If a sub-configuration has a "pin", it shall override the configuration's
-  // top-level "pin" value (if one was present). If no pin is specified, then
-  // the instruction shall be ignored.
-  //
-  // An action may specify verbs, each of which shall be executed in parallel.
-  // A verb key's value is a time value, indicating the duration (in
-  // milliseconds) of the action. The accuracy of the time value is laughable,
-  // and should not be relied on for fancy light shows at dance parties or
-  // night clubs. Unknown verbs are ignored.
-  //
-  // Currently, the supported verbs are:
-  //
-  //   - "set"
-  //
-  var verbs = [
-    "set"
-  ]
-  this.execute = function(config) {
-    if(typeof config === "object") {
-      if(!util.isArray(config))
-        config = [config]
+function GPIO() {
+}
 
-      //
-      // 1. Execute each subconfiguration in parallel
-      //
-      async.each(config, function(sub, done) {
+var pins = {}
 
-        //
-        // 2. Skip if subconfiguration is not an object
-        //
-        if(typeof sub !== "object" || util.isArray(sub))
-          return done(null)
-
-        //
-        // 3. Store default "pin" for subconfiguration, if present.
-        //
-        var pin = sub.pin || undefined
-
-        //
-        // 4. Store subconfiguration action, if present.
-        //
-        var action = sub.action || undefined
-        if(typeof action !== "object")
-          return done()
-
-        if(!util.isArray(action))
-          action = [action]
-
-        //
-        // 5. Execute each subconfiguration action, in series
-        //
-        async.eachSeries(action, function(act, done) {
-
-          //
-          // 6. Abort if 'act' is not an object.
-          //
-          if(typeof act !== "object" || util.isArray(act))
-            return done()
-
-          //
-          // 7. Use action's pin temporarily, if one is specified
-          //
-          var p = act.pin
-          if(typeof p === "undefined") p = pin
-
-          //
-          // 8. If no pin is specified, abort.
-          //
-          if(typeof p === "undefined")
-            return done()
-
-          // 9. Exececute each supported verb in parallel
-          async.every(verbs, function(verb, done) {
-            if(typeof act[verb] === "number") {
-              // If it's a number, then execute it.
-              execVerb[verb](p, act[verb], done)
-            } else done()
-          }, function(err) {
-            //
-            // Finished with verbs
-            //
-            done()
-          }) 
-        }, function(err) {
-          //
-          // Finished with actions
-          //
-          done()
+//
+// By the time these routines are called, 'pin' and 'time' should be
+// guaranteed to be valid, and 'done' is provided by the (internal)
+// caller itself. So we should be safe.
+//
+var execVerb = {
+  //
+  // Raise 'pin' for 'time' milliseconds
+  //
+  "set": function(pin, time, done) {
+    this.ensureReady(pin, gpio.DIR_OUT, function(err) {
+      if(err) console.log(err), done()
+      else
+        gpio.write(pin, true, function(err) {
+          // Should cancel all pending verbs? Not sure...
+          if(err) console.log(err), done()
+          else setTimeout(function() {
+            gpio.write(pin, false, function(err) {
+              if(err) console.log(err)
+              done()
+            })
+          }, time)
         })
-      }, function(err) {
-        //
-        // Finished with subconfigurations
-        //
-      })
-    }
-  }
-
-  this.pins = {}
-  this.ensureReady = function(pin, direction, done) {
-    //
-    // Only call setup when it really /needs/ to be called (which unfortunately)
-    // can't really be determined 100% here)
-    //
-    if(!this.pins[pin] || this.pins[pin] !== direction)
-      gpio.setup(pin, direction, function(err) {
-        if(err) return done(err)
-        else this.pins[pin] = direction, done()
-      })
-    else done()
-  }
-
-  //
-  // By the time these routines are called, 'pin' and 'time' should be
-  // guaranteed to be valid, and 'done' is provided by the (internal)
-  // caller itself. So we should be safe.
-  //
-  var execVerb = {
-    //
-    // Raise 'pin' for 'time' milliseconds
-    //
-    "set": function(pin, time, done) {
-      this.ensureReady(pin, gpio.DIR_OUT, function(err) {
-        if(err) console.log(err), done()
-        else
-          gpio.write(pin, true, function(err) {
-            // Should cancel all pending verbs? Not sure...
-            if(err) console.log(err), done()
-            else setTimeout(function() {
-              gpio.write(pin, false, function(err) {
-                if(err) console.log(err)
-                done()
-              })
-            }, time)
-          })
-      })
-    }
+    })
   }
 }
+
+
+GPIO.prototype.ensureReady = function(pin, direction, done) {
+  //
+  // Only call setup when it really /needs/ to be called (which unfortunately)
+  // can't really be determined 100% here)
+  //
+  if(!pins[pin] || pins[pin] !== direction)
+    gpio.setup(pin, direction, function(err) {
+      if(err) return done(err)
+      else pins[pin] = direction, done()
+    })
+  else done()
+}
+
+//
+// GPIO#execute(config)
+//
+// Parameters:
+//   config: An object containing a single GPIO configuration, made up of one 
+//           or more sub-configurations, each of which made up of one or more 
+//           actions (containing one or more verbs).
+//
+// Returns: undefined
+//
+// Description: Executes a set of GPIO instructions, using the following
+// algorithm:
+//
+// If configuration is an array, execute each element (sub-configuration) of
+// the array in parallel. Otherwise, treat the object as a single
+// sub-configuration and execute it.
+//
+// For each sub-configuration, there should be an "action" key. The value of
+// this action key may be an array or object. If it is an array, each element
+// in the array shall be executed in series.
+//
+// If a sub-configuration has a "pin", it shall override the configuration's
+// top-level "pin" value (if one was present). If no pin is specified, then
+// the instruction shall be ignored.
+//
+// An action may specify verbs, each of which shall be executed in parallel.
+// A verb key's value is a time value, indicating the duration (in
+// milliseconds) of the action. The accuracy of the time value is laughable,
+// and should not be relied on for fancy light shows at dance parties or
+// night clubs. Unknown verbs are ignored.
+//
+// Currently, the supported verbs are:
+//
+//   - "set"
+//
+var verbs = [
+  "set"
+]
+GPIO.prototype.execute = function(config) {
+  var self = this
+  if(typeof config === "object") {
+    if(!util.isArray(config))
+      config = [config]
+    //
+    // 1. Execute each subconfiguration in parallel
+    //
+    async.each(config, function(sub, done) {
+      //
+      // 2. Skip if subconfiguration is not an object
+      //
+      if(typeof sub !== "object" || util.isArray(sub))
+        return done(null)
+
+      //
+      // 3. Store default "pin" for subconfiguration, if present.
+      //
+      var pin = sub.pin || undefined
+      //
+      // 4. Store subconfiguration action, if present.
+      //
+      var action = sub.action || undefined
+      if(typeof action !== "object")
+        return done()
+
+      if(!util.isArray(action))
+        action = [action]
+
+      //
+      // 5. Execute each subconfiguration action, in series
+      //
+      async.eachSeries(action, function(act, done) {
+
+        //
+        // 6. Abort if 'act' is not an object.
+        //
+        if(typeof act !== "object" || util.isArray(act))
+          return done()
+
+        //
+        // 7. Use action's pin temporarily, if one is specified
+        //
+        var p = act.pin
+        if(typeof p === "undefined") p = pin
+
+        //
+        // 8. If no pin is specified, abort.
+        //
+        if(typeof p === "undefined")
+          return done()
+
+        // 9. Exececute each supported verb in parallel
+        async.every(verbs, function(verb, done) {
+          var value = act[verb]
+          if(typeof value === "number") {
+            // If it's a number, then execute it.
+            execVerb[verb].apply(self, [p, value, done])
+          } else done()
+        }, function(err) {
+          //
+          // Finished with verbs
+          //
+          done()
+        }) 
+      }, function(err) {
+        //
+        // Finished with actions
+        //
+        done()
+      })
+    }, function(err) {
+      //
+      // Finished with subconfigurations
+      //
+    })
+  }
+}
+
+module.exports.GPIO = new GPIO

--- a/lib/gpio.js
+++ b/lib/gpio.js
@@ -3,6 +3,11 @@ var parseJson = require('./parseJson'),
     async = require('async'),
     util = require('util')
 
+// Ensure that GPIO is destroyed and pins are unexported on exit.
+process.on('exit', function() {
+  gpio.destroy()
+})
+
 //
 // GPIO configuration keys:
 //
@@ -214,6 +219,20 @@ module.exports.GPIO = function() {
     }
   }
 
+  this.pins = {}
+  this.ensureReady = function(pin, direction, done) {
+    //
+    // Only call setup when it really /needs/ to be called (which unfortunately)
+    // can't really be determined 100% here)
+    //
+    if(!this.pins[pin] || this.pins[pin] !== direction)
+      gpio.setup(pin, direction, function(err) {
+        if(err) return done(err)
+        else this.pins[pin] = direction, done()
+      })
+    else done()
+  }
+
   //
   // By the time these routines are called, 'pin' and 'time' should be
   // guaranteed to be valid, and 'done' is provided by the (internal)
@@ -224,17 +243,20 @@ module.exports.GPIO = function() {
     // Raise 'pin' for 'time' milliseconds
     //
     "set": function(pin, time, done) {
-      gpio.setup(pin, gpio.DIR_OUT, function() {
-        gpio.write(pin, true, function(err) {
-          if(err) console.log(err)
-          setTimeout(function() {
-            gpio.write(pin, false, function(err) {
-              if(err) console.log(err)
-            })
-          }, time)
-        })
+      this.ensureReady(pin, gpio.DIR_OUT, function(err) {
+        if(err) console.log(err), done()
+        else
+          gpio.write(pin, true, function(err) {
+            // Should cancel all pending verbs? Not sure...
+            if(err) console.log(err), done()
+            else setTimeout(function() {
+              gpio.write(pin, false, function(err) {
+                if(err) console.log(err)
+                done()
+              })
+            }, time)
+          })
       })
-      done()
     }
   }
 }


### PR DESCRIPTION
This version should cache already-setup pins in an object, and only setup
again if the direction changes, or if the pin is not cached as exported.
Additionally, this version adds a handler for the process 'exit' event, which
should unexport all pins when the app is killed or exited.
